### PR TITLE
[DO NOT MERGE] Scratch branch for adding a namespace

### DIFF
--- a/examples/gke-regional-public-cluster/variables.tf
+++ b/examples/gke-regional-public-cluster/variables.tf
@@ -5,10 +5,12 @@
 
 variable "project" {
   description = "The name of the GCP Project where all resources will be launched."
+  default = "graphite-test-rileykarson"
 }
 
 variable "region" {
   description = "The Region in which all GCP resources will be launched."
+  default = "us-central1"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
/cc @robmorgan 

Context: https://github.com/coreos/prometheus-operator/issues/357

See note at https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#defining_permissions_in_a_role

The issue is that applying RoleBindings to my persistent service account / Google account isn't working; when creating namespaces, I get the error that `107951173914973741799` doesn't have permissions. My email (for my  service account) is getting scrunched into that. It _might_ be an oauth scope on the node pool? but I'm not sure how that would affect operations on the master.

```
Error: Error applying plan:

2 error(s) occurred:

* module.namespace.kubernetes_role.rbac_role_access_all: 1 error(s) occurred:

* kubernetes_role.rbac_role_access_all: roles.rbac.authorization.k8s.io "my-new-namespace-access-all" is forbidden: attempt to grant extra privileges: [{[*] [*] [*] [] []}] user=&{107951173914973741799  [system:authenticated] map[user-assertion.cloud.google.com:[APTNk9QHwMRRqw+/OP5WhhQlROAy9ysI34o5YstxQZvarLlFsg8IocTmsl0OMGUbiseGNfCyOjPgtgAmPtw3hMiyBVgRNK4Uje1c781sdxC8qDO5kzSBSDXUoBfJGmXcgsqrc9dMeB2KNunkRzpqNUqJvXV8mIo4YIWTxlzcv08j04APwSBOhojnRS+L8Ann2jOtZKM8apG3ICaxB+MtJCQDTeZ8IBFnYTCnTVRpTQ==]]} ownerrules=[{[create] [authorization.k8s.io] [selfsubjectaccessreviews selfsubjectrulesreviews] [] []} {[get] [] [] [] [/api /api/* /apis /apis/* /healthz /openapi /openapi/* /swagger-2.0.0.pb-v1 /swagger.json /swaggerapi /swaggerapi/* /version /version/]}] ruleResolutionErrors=[]
* module.namespace.kubernetes_role.rbac_role_access_read_only: 1 error(s) occurred:

* kubernetes_role.rbac_role_access_read_only: roles.rbac.authorization.k8s.io "my-new-namespace-access-read-only" is forbidden: attempt to grant extra privileges: [{[list] [*] [*] [] []} {[watch] [*] [*] [] []} {[get] [*] [*] [] []}] user=&{107951173914973741799  [system:authenticated] map[user-assertion.cloud.google.com:[APTNk9QHwMRRqw+/OP5WhhQlROAy9ysI34o5YstxQZvarLlFsg8IocTmsl0OMGUbiseGNfCyOjPgtgAmPtw3hMiyBVgRNK4Uje1c781sdxC8qDO5kzSBSDXUoBfJGmXcgsqrc9dMeB2KNunkRzpqNUqJvXV8mIo4YIWTxlzcv08j04APwSBOhojnRS+L8Ann2jOtZKM8apG3ICaxB+MtJCQDTeZ8IBFnYTCnTVRpTQ==]]} ownerrules=[{[create] [authorization.k8s.io] [selfsubjectaccessreviews selfsubjectrulesreviews] [] []} {[get] [] [] [] [/api /api/* /apis /apis/* /healthz /openapi /openapi/* /swagger-2.0.0.pb-v1 /swagger.json /swaggerapi /swaggerapi/* /version /version/]}] ruleResolutionErrors=[]

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

