### PR TITLE
Forgot environment variables

### DIFF
--- a/examples/gke-basic-tiller/main.tf
+++ b/examples/gke-basic-tiller/main.tf
@@ -307,6 +307,13 @@ module "tiller" {
 resource "null_resource" "wait_for_tiller" {
   provisioner "local-exec" {
     command = "kubergrunt helm wait-for-tiller --tiller-namespace ${local.tiller_namespace} --tiller-deployment-name ${module.tiller.deployment_name} --expected-tiller-version ${local.tiller_version} ${local.kubectl_auth_config}"
+
+    # Use environment variables for Kubernetes credentials to avoid leaking into the logs
+    environment = {
+      KUBECTL_SERVER_ENDPOINT = "${data.template_file.gke_host_endpoint.rendered}"
+      KUBECTL_CA_DATA         = "${base64encode(data.template_file.cluster_ca_certificate.rendered)}"
+      KUBECTL_TOKEN           = "${data.template_file.access_token.rendered}"
+    }
   }
 }
 

--- a/examples/gke-private-tiller/main.tf
+++ b/examples/gke-private-tiller/main.tf
@@ -324,6 +324,13 @@ module "tiller" {
 resource "null_resource" "wait_for_tiller" {
   provisioner "local-exec" {
     command = "kubergrunt helm wait-for-tiller --tiller-namespace ${local.tiller_namespace} --tiller-deployment-name ${module.tiller.deployment_name} --expected-tiller-version ${local.tiller_version} ${local.kubectl_auth_config}"
+
+    # Use environment variables for Kubernetes credentials to avoid leaking into the logs
+    environment = {
+      KUBECTL_SERVER_ENDPOINT = "${data.template_file.gke_host_endpoint.rendered}"
+      KUBECTL_CA_DATA         = "${base64encode(data.template_file.cluster_ca_certificate.rendered)}"
+      KUBECTL_TOKEN           = "${data.template_file.access_token.rendered}"
+    }
   }
 }
 


### PR DESCRIPTION
I forgot to include the environment variables for auth in the `kubergrunt` call for `wait-for-tiller`. It nondeterministically works right now, as there is a race between setting up `kubectl` and the `kubergrunt` call.

NOTE: this needs to be replicated to https://github.com/gruntwork-io/terraform-google-gke/pull/31