### PR TITLE
Use Stackdriver Kubernetes Engine Monitoring as default instead of Legacy Stackdriver

### DIFF
--- a/modules/gke-cluster/README.md
+++ b/modules/gke-cluster/README.md
@@ -96,6 +96,23 @@ region as your private cluster, can use the private endpoint.
 
 You can relax the restrictions by authorizing certain address ranges to access the endpoints with the input variable
 `master_authorized_networks_config`.
+
+### How do I configure logging and monitoring with Stackdriver for my cluster?
+
+Stackdriver Kubernetes Engine Monitoring is enabled by default using this module. It provides improved support for both
+Stackdriver Monitoring and Stackdriver Logging in your cluster, including a GKE-customized Stackdriver Console with
+fine-grained breakdown of resources including namespaces and pods. Learn more with the [official documentation](https://cloud.google.com/monitoring/kubernetes-engine/#about-skm)
+
+Although Stackdriver Kubernetes Engine Monitoring is enabled by default, you can use the legacy Stackdriver options by
+modifying your configuration. See the [differences between GKE Stackdriver versions](https://cloud.google.com/monitoring/kubernetes-engine/#version)
+for the differences between legacy Stackdriver and Stackdriver Kubernetes Engine Monitoring.
+
+#### How do I use Prometheus for monitoring?
+
+Prometheus monitoring for your cluster is ready to go through GCP's Stackdriver Kubernetes Engine Monitoring service. If
+you've configured your GKE cluster with Stackdriver Kubernetes Engine Monitoring, you can follow Google's guide to
+[using Prometheus](https://cloud.google.com/monitoring/kubernetes-engine/prometheus) to configure your cluster with
+Prometheus.
  
 ### Private cluster restrictions and limitations
 

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -43,13 +43,13 @@ variable "kubernetes_version" {
 }
 
 variable "logging_service" {
-  description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
-  default     = "logging.googleapis.com"
+  description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com/kubernetes, logging.googleapis.com (legacy), and none"
+  default     = "logging.googleapis.com/kubernetes"
 }
 
 variable "monitoring_service" {
-  description = "The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Stackdriver Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none"
-  default     = "monitoring.googleapis.com"
+  description = "The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Stackdriver Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting. Available options include monitoring.googleapis.com/kubernetes, monitoring.googleapis.com (legacy), and none"
+  default     = "monitoring.googleapis.com/kubernetes"
 }
 
 variable "horizontal_pod_autoscaling" {


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terraform-google-gke/issues/41

This was released as GA on [May 20th](https://cloud.google.com/kubernetes-engine/docs/release-notes#may_20_2019). It will become the default logging / monitoring service for GKE beginning in `1.14.X` series releases, which will go GA ~3 months after `1.13.X` (May 13th).

As I understand it, this isn't a breaking change for _Kubernetes_, but is for _Stackdriver_ as the cluster will output different fields. We should probably bump our minor version based on that, or hold this is a default until later.