### PR TITLE
Evaluation of latest_node_version outside of ternary operation (unknown values during apply)

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -105,7 +105,8 @@ resource "google_container_cluster" "cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 locals {
-  kubernetes_version = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.location.latest_node_version
+  latest_version     = data.google_container_engine_versions.location.latest_node_version
+  kubernetes_version = var.kubernetes_version != "latest" ? var.kubernetes_version : local.latest_version
   network_project    = var.network_project != "" ? var.network_project : var.project
 }
 


### PR DESCRIPTION
There is a bug in terraform which prevent the evaluation of data.google_container_engine_versions.location if it is in a ternary operation.


```
Error: configuration for data.google_container_engine_versions.location still contains unknown values during apply (this is a bug in Terraform; please report it!)
```

The equivalent problem is https://github.com/hashicorp/terraform/issues/21465
Since terraform team is working on it, I felt like I should let you know. 
This PR contains the workaround that bug. 

Feel free to discard this PR. 
This is to open a discussion on how to deal with bug in terraform.

Have a great day,

Julien