### PR TITLE
fix: Add missing Stackdriver permission

### DIFF
--- a/modules/gke-service-account/main.tf
+++ b/modules/gke-service-account/main.tf
@@ -22,3 +22,9 @@ resource "google_project_iam_member" "service_account-monitoring_viewer" {
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }
+
+resource "google_project_iam_member" "service_account-resource-metadata-writer" {
+  project = google_project_iam_member.service_account-monitoring_viewer.project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+}


### PR DESCRIPTION
There is an undocumented Role needed (see https://github.com/Stackdriver/kubernetes-configs/issues/25#issuecomment-493431063) to use the new stackdriver for Kubernetes, else this happens:

```
W0627 11:44:41.308933       1 kubernetes.go:113] Failed to publish resource metadata: rpc error: code = PermissionDenied desc = The caller does not have permission
W0627 11:44:41.408116       1 kubernetes.go:113] Failed to publish resource metadata: rpc error: code = PermissionDenied desc = The caller does not have permission
W0627 11:44:41.635170       1 kubernetes.go:113] Failed to publish resource metadata: rpc error: code = PermissionDenied desc = The caller does not have permission
W0627 11:44:42.107927       1 kubernetes.go:113] Failed to publish resource metadata: rpc error: code = PermissionDenied desc = The caller does not have permission
W0627 11:44:42.308177       1 kubernetes.go:113] Failed to publish resource metadata: rpc error: code = PermissionDenied desc = The caller does not have permission
W06
```