### PR TITLE
Use latest_master_version for latest k8s version

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -105,7 +105,7 @@ resource "google_container_cluster" "cluster" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 locals {
-  latest_version     = data.google_container_engine_versions.location.latest_node_version
+  latest_version     = data.google_container_engine_versions.location.latest_master_version
   kubernetes_version = var.kubernetes_version != "latest" ? var.kubernetes_version : local.latest_version
   network_project    = var.network_project != "" ? var.network_project : var.project
 }


### PR DESCRIPTION
Instead of using the latest _node_ version, use the latest _master_ version - after all, the k8s version is used to set `min_master_version`

This PR changes the logic for deriving the latest available k8s version so that the latest available GKE master version is used, instead of the latest available node version.

This avoids issues where a new node version is available but no new master version is - in such a case `google_container_cluster` would previously fail because it uses the kubernetes version to set the `min_master_version`.