### PR TITLE
Update min required version of TF in example READMEs

### DIFF
--- a/examples/gke-private-cluster/README.md
+++ b/examples/gke-private-cluster/README.md
@@ -37,7 +37,7 @@ Currently, you cannot use a proxy to reach the cluster master of a regional clus
 
 ## How do you run these examples?
 
-1. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) v0.10.3 or later.
+1. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) v0.12.0 or later.
 1. Open `variables.tf` and fill in any required variables that don't have a default.
 1. Run `terraform get`.
 1. Run `terraform plan`.

--- a/examples/gke-public-cluster/README.md
+++ b/examples/gke-public-cluster/README.md
@@ -51,7 +51,7 @@ your new zones are within the region your cluster is present in.
 
 ## How do you run these examples?
 
-1. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) v0.10.3 or later.
+1. Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) v0.12.0 or later.
 1. Open `variables.tf`, and fill in any required variables that don't have a default.
 1. Run `terraform get`.
 1. Run `terraform plan`.


### PR DESCRIPTION
# what

Correct the version of Terraform required in two README files in the examples directory. As main.tf specifies, the min required version of TF is 0.12.0.

# why

To avoid possible confusion on behalf of new module users

# notes

I read the contributing guidelines but forwent creating an issue because this is a very small change that doesn't affect the main documentation, the tests, or the code.