### PR TITLE
Add Storage Object Viewer role to service account

### DIFF
--- a/modules/gke-service-account/main.tf
+++ b/modules/gke-service-account/main.tf
@@ -1,14 +1,26 @@
+# ----------------------------------------------------------------------------------------------------------------------
+# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
+# This module uses terraform 0.12 syntax and features that are available only
+# since version 0.12.6
+# ----------------------------------------------------------------------------------------------------------------------
 terraform {
   required_version = ">= 0.12.6"
 }
 
+# ----------------------------------------------------------------------------------------------------------------------
+# CREATE SERVICE ACCOUNT
+# ----------------------------------------------------------------------------------------------------------------------
 resource "google_service_account" "service_account" {
   project      = var.project
   account_id   = var.name
   display_name = var.description
 }
 
+# ----------------------------------------------------------------------------------------------------------------------
+# ADD ROLES TO SERVICE ACCOUNT
 # Grant the service account the minimum necessary roles and permissions in order to run the GKE cluster
+# plus any other roles added through the 'service_account_roles' variable
+# ----------------------------------------------------------------------------------------------------------------------
 locals {
   all_service_account_roles = concat(var.service_account_roles, [
     "roles/logging.logWriter",

--- a/modules/gke-service-account/main.tf
+++ b/modules/gke-service-account/main.tf
@@ -5,33 +5,20 @@ resource "google_service_account" "service_account" {
 }
 
 # Grant the service account the minimum necessary roles and permissions in order to run the GKE cluster
-resource "google_project_iam_member" "service_account-log_writer" {
-  project = google_service_account.service_account.project
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.service_account.email}"
+locals {
+  all_service_account_roles = concat(var.service_account_roles, [
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/stackdriver.resourceMetadata.writer",
+    "roles/storage.objectViewer"
+  ])
 }
 
-resource "google_project_iam_member" "service_account-metric_writer" {
-  project = google_project_iam_member.service_account-log_writer.project
-  role    = "roles/monitoring.metricWriter"
-  member  = "serviceAccount:${google_service_account.service_account.email}"
-}
+resource "google_project_iam_member" "service_account-roles" {
+  for_each = toset(local.all_service_account_roles)
 
-resource "google_project_iam_member" "service_account-monitoring_viewer" {
-  project = google_project_iam_member.service_account-metric_writer.project
-  role    = "roles/monitoring.viewer"
-  member  = "serviceAccount:${google_service_account.service_account.email}"
-}
-
-resource "google_project_iam_member" "service_account-resource_metadata_writer" {
-  project = google_project_iam_member.service_account-monitoring_viewer.project
-  role    = "roles/stackdriver.resourceMetadata.writer"
-  member  = "serviceAccount:${google_service_account.service_account.email}"
-}
-
-# Necessary for pulling images from the Container Registry
-resource "google_project_iam_member" "service_account-storage_object_viewer" {
-  project = google_project_iam_member.service_account-resource_metadata_writer.project
-  role    = "roles/storage.objectViewer"
+  project = var.project
+  role    = each.value
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }

--- a/modules/gke-service-account/main.tf
+++ b/modules/gke-service-account/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12.6"
+}
+
 resource "google_service_account" "service_account" {
   project      = var.project
   account_id   = var.name

--- a/modules/gke-service-account/main.tf
+++ b/modules/gke-service-account/main.tf
@@ -23,8 +23,15 @@ resource "google_project_iam_member" "service_account-monitoring_viewer" {
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
-resource "google_project_iam_member" "service_account-resource-metadata-writer" {
+resource "google_project_iam_member" "service_account-resource_metadata_writer" {
   project = google_project_iam_member.service_account-monitoring_viewer.project
   role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+# Necessary for pulling images from the Container Registry
+resource "google_project_iam_member" "service_account-storage_object_viewer" {
+  project = google_project_iam_member.service_account-resource_metadata_writer.project
+  role    = "roles/storage.objectViewer"
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }

--- a/modules/gke-service-account/main.tf
+++ b/modules/gke-service-account/main.tf
@@ -26,8 +26,7 @@ locals {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer",
-    "roles/stackdriver.resourceMetadata.writer",
-    "roles/storage.objectViewer"
+    "roles/stackdriver.resourceMetadata.writer"
   ])
 }
 

--- a/modules/gke-service-account/variables.tf
+++ b/modules/gke-service-account/variables.tf
@@ -23,3 +23,9 @@ variable "description" {
   type        = string
   default     = ""
 }
+
+variable "service_account_roles" {
+  description = "Additional roles to be added to the service account."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
It is necessary for pulling private images from the Container Registry. Without this role only public images can be pulled and deploying a k8s-service with a private image fails with `ImagePullBackOff` status. 