### PR TITLE
Fix cluster recreate on reapply

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -122,6 +122,14 @@ resource "google_container_cluster" "cluster" {
       start_time = var.maintenance_start_time
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Since we provide `remove_default_node_pool = true`, the `node_config` is only relevant for a valid construction of
+      # the GKE cluster in the initial creation. As such, any changes to the `node_config` should be ignored.
+      "node_config",
+    ]
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes https://github.com/gruntwork-io/terraform-google-gke/issues/59: any changes to the `node_config` should be ignored on the resource because it is only relevant in the initial creation. However, because of the way terraform and the GKE API works, you could end up in a situation where TF detects a diff in the `node_config` after cluster creation, leading to TF wanting to recreate the cluster, which is detrimental!

We workaround this limitation by adding a `lifecycle.ignore_changes` block config for the `node_config` attribute so that changes to that are ignored by TF.

Note that this adds a regression test by adding a step to `TestGKECluster` which checks the plan after the cluster is deployed to verify there are no changes.