### PR TITLE
Add G Suite RBAC capability

### DIFF
--- a/examples/gke-basic-tiller/main.tf
+++ b/examples/gke-basic-tiller/main.tf
@@ -15,7 +15,7 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 
@@ -32,7 +32,7 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 

--- a/examples/gke-private-cluster/main.tf
+++ b/examples/gke-private-cluster/main.tf
@@ -14,13 +14,13 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 }

--- a/examples/gke-public-cluster/main.tf
+++ b/examples/gke-public-cluster/main.tf
@@ -15,13 +15,13 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 
@@ -31,7 +31,7 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = "~> 2.7.0"
+  version = "~> 2.9.0"
   project = var.project
   region  = var.region
 

--- a/modules/gke-cluster/README.md
+++ b/modules/gke-cluster/README.md
@@ -129,8 +129,15 @@ Internet gateway, causes a private cluster to stop functioning.
 ## How do I configure the cluster to use Google Groups for GKE?
 
 If you want to enable Google Groups for use with RBAC, you have to provide a G Suite domain name using input variable `var.gsuite_domain_name`. If a 
-value is provided, the cluster will be initialised with a security group `gke-security-groups@[yourdomain.com]`. After the 
-cluster has been created, you are ready to create Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings that reference 
-your G Suite Google Groups. Note that you cannot enable this feature on existing clusters.
+value is provided, the cluster will be initialised with a security group `gke-security-groups@[yourdomain.com]`. 
+
+In G Suite, you will have to:
+
+1. Create a G Suite Google Group in your domain, named gke-security-groups@[yourdomain.com]. The group must be named exactly gke-security-groups.
+1. Create groups, if they do not already exist, that represent groups of users or groups who should have different permissions on your clusters.
+1. Add these groups (not users) to the membership of gke-security-groups@[yourdomain.com].
+
+After the cluster has been created, you are ready to create Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings 
+that reference your G Suite Google Groups. Note that you cannot enable this feature on existing clusters. 
 
 For more information, see https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#google-groups-for-gke.

--- a/modules/gke-cluster/README.md
+++ b/modules/gke-cluster/README.md
@@ -125,3 +125,12 @@ Private clusters have the following restrictions and limitations:
 * Deleting the VPC peering between the cluster master and the cluster nodes, deleting the firewall rules that allow 
 ingress traffic from the cluster master to nodes on port 10250, or deleting the default route to the default 
 Internet gateway, causes a private cluster to stop functioning.
+
+## How do I configure the cluster to use Google Groups for GKE?
+
+If you want to enable Google Groups for use with RBAC, you have to provide a G Suite domain name using input variable `var.gsuite_domain_name`. If a 
+value is provided, the cluster will be initialised with a security group `gke-security-groups@[yourdomain.com]`. After the 
+cluster has been created, you are ready to create Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings that reference 
+your G Suite Google Groups. Note that you cannot enable this feature on existing clusters.
+
+For more information, see https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#google-groups-for-gke.

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -18,6 +18,8 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "google_container_cluster" "cluster" {
+  provider = "google-beta"
+
   name        = var.name
   description = var.description
 
@@ -129,6 +131,17 @@ resource "google_container_cluster" "cluster" {
       # the GKE cluster in the initial creation. As such, any changes to the `node_config` should be ignored.
       "node_config",
     ]
+  }
+
+  # If a var.gsuite_domain_name is non-empty, initialize the cluster with a G Suite security group
+  dynamic "authenticator_groups_config" {
+    for_each = [
+      for x in [var.gsuite_domain_name] : x if var.gsuite_domain_name != null
+    ]
+
+    content {
+      security_group = "gke-security-groups@${authenticator_groups_config.value}"
+    }
   }
 }
 

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -190,3 +190,10 @@ variable "enable_client_certificate_authentication" {
   type        = bool
   default     = false
 }
+
+# See https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#google-groups-for-gke
+variable "gsuite_domain_name" {
+  description = "The domain name for use with Google security groups in Kubernetes RBAC. If a value is provided, the cluster will be initialized with security group `gke-security-groups@[yourdomain.com]`."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This PR add ability to configure G Suite `security-group` when creating a cluster. You must create a new cluster to enable this feature:

```
      + authenticator_groups_config { # forces replacement
          + security_group = "gke-security-groups@acme.com" # forces replacement
        }

```
As this is `beta` feature, the cluster has to be created with the `google-beta` -provider, version = "~> 2.9.0"