### PR TITLE
Upgrade blog post example to tf12

### DIFF
--- a/backing_file.tf
+++ b/backing_file.tf
@@ -10,9 +10,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.6.0"
-  project = "${var.project}"
-  region  = "${var.region}"
+  version = "~> 2.9.0"
+  project = var.project
+  region  = var.region
 
   scopes = [
     # Default scopes
@@ -28,9 +28,9 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = "~> 2.6.0"
-  project = "${var.project}"
-  region  = "${var.region}"
+  version = "~> 2.9.0"
+  project = var.project
+  region  = var.region
 
   scopes = [
     # Default scopes

--- a/backing_file.tf
+++ b/backing_file.tf
@@ -3,10 +3,8 @@
 # to create your Terraform resources.
 # ---------------------------------------------------------------------------------------------------------------------
 
-# Use Terraform 0.10.x so that we can take advantage of Terraform GCP functionality as a separate provider via
-# https://github.com/terraform-providers/terraform-provider-google
 terraform {
-  required_version = ">= 0.10.3"
+  required_version = ">= 0.12.7"
 }
 
 provider "google" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@
 
 variable "project" {
   description = "The project ID where all resources will be launched."
+  type        = string
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -14,26 +15,31 @@ variable "project" {
 
 variable "location" {
   description = "The location (region or zone) of the GKE cluster."
+  type        = string
   default     = "us-central1"
 }
 
 variable "region" {
   description = "The region for the network. If the cluster is regional, this must be the same region. Otherwise, it should be the region of the zone."
+  type        = string
   default     = "us-central1"
 }
 
 variable "cluster_name" {
   description = "The name of the Kubernetes cluster."
+  type        = string
   default     = "example-cluster"
 }
 
 variable "cluster_service_account_name" {
   description = "The name of the custom service account used for the GKE cluster. This parameter is limited to a maximum of 28 characters."
+  type        = string
   default     = "example-cluster-sa"
 }
 
 variable "cluster_service_account_description" {
   description = "A description of the custom service account used for the GKE cluster."
+  type        = string
   default     = "Example GKE Cluster Service Account managed by Terraform"
 }
 
@@ -41,7 +47,7 @@ variable "cluster_service_account_description" {
 
 variable "tls_subject" {
   description = "The issuer information that contains the identifying information for the Tiller server. Used to generate the TLS certificate keypairs."
-  type        = "map"
+  type        = map(string)
 
   default = {
     common_name = "tiller"
@@ -59,7 +65,7 @@ variable "tls_subject" {
 
 variable "client_tls_subject" {
   description = "The issuer information that contains the identifying information for the helm client of the operator. Used to generate the TLS certificate keypairs."
-  type        = "map"
+  type        = map(string)
 
   default = {
     common_name = "admin"
@@ -79,6 +85,7 @@ variable "client_tls_subject" {
 
 variable "private_key_algorithm" {
   description = "The name of the algorithm to use for private keys. Must be one of: RSA or ECDSA."
+  type        = string
   default     = "ECDSA"
 }
 
@@ -89,6 +96,7 @@ variable "private_key_ecdsa_curve" {
 
 variable "private_key_rsa_bits" {
   description = "The size of the generated RSA key in bits. Should only be used if var.private_key_algorithm is RSA."
+  type        = string
   default     = "2048"
 }
 
@@ -96,11 +104,13 @@ variable "private_key_rsa_bits" {
 
 variable "force_undeploy" {
   description = "If true, will remove the Tiller server resources even if there are releases deployed."
+  type        = bool
   default     = false
 }
 
 variable "undeploy_releases" {
   description = "If true, will delete deployed releases from the Tiller instance before undeploying Tiller."
+  type        = bool
   default     = false
 }
 
@@ -108,6 +118,7 @@ variable "undeploy_releases" {
 # you will have to adjust the 'cidr_subnetwork_width_delta' in the 'vpc_network' -module accordingly.
 variable "vpc_cidr_block" {
   description = "The IP address range of the VPC in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27."
+  type        = string
   default     = "10.1.0.0/16"
 }
 
@@ -115,5 +126,6 @@ variable "vpc_cidr_block" {
 # you will have to adjust the 'cidr_subnetwork_width_delta' in the 'vpc_network' -module accordingly.
 variable "vpc_secondary_cidr_block" {
   description = "The IP address range of the VPC's secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27."
+  type        = string
   default     = "10.2.0.0/16"
 }


### PR DESCRIPTION
This PR upgrades the blog post example to be compatible with `terraform 0.12.x`.

Fixes #72 