### PR TITLE
Adding support for shielded-nodes

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -42,6 +42,9 @@ resource "google_container_cluster" "cluster" {
 
   initial_node_count = 1
 
+  # Support shielded nodes, requires google-beta version 2.18.0
+  enable_shielded_nodes = var.enable_shielded_nodes
+
   # If we have an alternative default service account to use, set on the node_config so that the default node pool can
   # be created successfully.
   dynamic "node_config" {

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -108,7 +108,7 @@ variable "master_authorized_networks_config" {
       display_name = "example_network"
     }],
   }]
-  
+
 EOF
   type        = list(any)
   default     = []
@@ -148,6 +148,12 @@ variable "alternative_default_service_account" {
   description = "Alternative Service Account to be used by the Node VMs. If not specified, the default compute Service Account will be used. Provide if the default Service Account is no longer available."
   type        = string
   default     = null
+}
+
+variable "enable_shielded_nodes" {
+  description = "Enable Shielded Nodes features on all nodes in this cluster."
+  type        = bool
+  default     = false
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Changes:
* Adds option to use the  `enable_shielded_nodes` feature from `google-beta` `v2.18.0+`

This change effectively bumps the version requirement of `google-beta` to `v2.18.0+`. Is there a backwards compatibility concern with this?