### PR TITLE
Add vertical pod autoscaling option

### DIFF
--- a/examples/gke-private-cluster/main.tf
+++ b/examples/gke-private-cluster/main.tf
@@ -69,6 +69,8 @@ module "gke_cluster" {
   ]
 
   cluster_secondary_range_name = module.vpc_network.public_subnetwork_secondary_range_name
+
+  enable_vertical_pod_autoscaling = var.enable_vertical_pod_autoscaling
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/gke-private-cluster/variables.tf
+++ b/examples/gke-private-cluster/variables.tf
@@ -62,3 +62,9 @@ variable "vpc_secondary_cidr_block" {
   type        = string
   default     = "10.4.0.0/16"
 }
+
+variable "enable_vertical_pod_autoscaling" {
+  description = "Enable vertical pod autoscaling"
+  type        = string
+  default     = true
+}

--- a/examples/gke-public-cluster/main.tf
+++ b/examples/gke-public-cluster/main.tf
@@ -50,6 +50,8 @@ module "gke_cluster" {
   cluster_secondary_range_name = module.vpc_network.public_subnetwork_secondary_range_name
 
   alternative_default_service_account = var.override_default_node_pool_service_account ? module.gke_service_account.email : null
+
+  enable_vertical_pod_autoscaling = var.enable_vertical_pod_autoscaling
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/gke-public-cluster/variables.tf
+++ b/examples/gke-public-cluster/variables.tf
@@ -57,6 +57,12 @@ variable "vpc_secondary_cidr_block" {
   default     = "10.7.0.0/16"
 }
 
+variable "enable_vertical_pod_autoscaling" {
+  description = "Enable vertical pod autoscaling"
+  type        = string
+  default     = true
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # TEST PARAMETERS
 # These parameters are only used during testing and should not be touched.

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -93,6 +93,10 @@ resource "google_container_cluster" "cluster" {
     provider = "CALICO"
   }
 
+  vertical_pod_autoscaling {
+    enabled = var.enable_vertical_pod_autoscaling
+  }
+
   master_auth {
     username = var.basic_auth_username
     password = var.basic_auth_password

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -108,7 +108,6 @@ variable "master_authorized_networks_config" {
       display_name = "example_network"
     }],
   }]
-  
 EOF
   type        = list(any)
   default     = []
@@ -196,4 +195,11 @@ variable "secrets_encryption_kms_key" {
   description = "The Cloud KMS key to use for the encryption of secrets in etcd, e.g: projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"
   type        = string
   default     = null
+}
+
+# See https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler
+variable "enable_vertical_pod_autoscaling" {
+  description = "Whether to enable Vertical Pod Autoscaling"
+  type        = string
+  default     = false
 }


### PR DESCRIPTION
- added option to enable vertical pod autoscaling
- set vertical pod autoscaling to `true` for public and private test clusters
- tested with `go test -v -timeout 60m -run TestGKECluster`

This is a backwards compatible change. Clusters deployed with `v0.4.0` of this module have vertical autoscaling disabled, which is the default behavior for this change.

The first run with this module will give the following terraform plan for clusters deployed with v0.4.0 of this module:
```
      + vertical_pod_autoscaling {
          + enabled = false
        }
```

Despite autoscaling already being disabled, Terraform wants to apply the change anyway. The change is applied in place quickly without actually changing anything. This is only for the initial run after upgrading the module.

resolves https://github.com/gruntwork-io/terraform-google-gke/issues/83


