### PR TITLE
Fix version argument inside provider configuration deprecation warning

### DIFF
--- a/examples/gke-private-cluster/main.tf
+++ b/examples/gke-private-cluster/main.tf
@@ -8,6 +8,17 @@ terraform {
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 0.13.x code.
   required_version = ">= 0.12.26"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 3.43.0"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+      version = "~> 3.43.0"
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -15,13 +26,11 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  version = "~> 3.43.0"
   project = var.project
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 3.43.0"
   project = var.project
   region  = var.region
 }

--- a/examples/gke-public-cluster/main.tf
+++ b/examples/gke-public-cluster/main.tf
@@ -9,6 +9,17 @@ terraform {
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 0.13.x code.
   required_version = ">= 0.12.26"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 3.43.0"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+      version = "~> 3.43.0"
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -16,13 +27,11 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 provider "google" {
-  version = "~> 3.43.0"
   project = var.project
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 3.43.0"
   project = var.project
   region  = var.region
 }


### PR DESCRIPTION
Fix the following warning when running examples. Should I bump the required version to 0.13 at least? 

```
Warning: Version constraints inside provider configuration blocks are deprecated

  on main.tf line 34, in provider "google-beta":
  34:   version = "~> 3.43.0"
```
