### PR TITLE
Feat: Added release_channel variable to pin cluster to specific release channel

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -34,7 +34,15 @@ resource "google_container_cluster" "cluster" {
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
-  min_master_version = local.kubernetes_version
+  min_master_version = var.release_channel != null ? null : local.kubernetes_version
+
+  dynamic "release_channel" {
+    for_each = local.release_channel
+
+    content {
+      channel = release_channel.value.channel
+    }
+  }
 
   # Whether to enable legacy Attribute-Based Access Control (ABAC). RBAC has significant security advantages over ABAC.
   enable_legacy_abac = var.enable_legacy_abac
@@ -178,6 +186,7 @@ locals {
   latest_version     = data.google_container_engine_versions.location.latest_master_version
   kubernetes_version = var.kubernetes_version != "latest" ? var.kubernetes_version : local.latest_version
   network_project    = var.network_project != "" ? var.network_project : var.project
+  release_channel    = var.release_channel != null ? [{ channel : var.release_channel }] : []
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -151,7 +151,7 @@ variable "alternative_default_service_account" {
 
 variable "resource_labels" {
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster."
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
@@ -225,5 +225,11 @@ variable "enable_workload_identity" {
 variable "identity_namespace" {
   description = "Workload Identity Namespace. Default sets project based namespace [project_id].svc.id.goog"
   default     = null
+  type        = string
+}
+
+variable "release_channel" {
+  default     = null
+  description = "(Optional) The release channel to get upgrades of your GKE clusters from"
   type        = string
 }


### PR DESCRIPTION
We are currently facing this issue where terraform tries to upgrade the Cluster on every GKE release because the release channel is not set. Since we want to run on production we want to pin the terraform release version to`stable` to prevent unnecessary upgrades.

Closes #116 