### PR TITLE
fix: pod secondary range name should not be same as service secondary range name

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -68,7 +68,7 @@ resource "google_container_cluster" "cluster" {
   ip_allocation_policy {
     // Choose the range, but let GCP pick the IPs within the range
     cluster_secondary_range_name  = var.cluster_secondary_range_name
-    services_secondary_range_name = var.services_secondary_range_name != null ? var.services_secondary_range_name : var.cluster_secondary_range_name
+    services_secondary_range_name = var.services_secondary_range_name
   }
 
   # We can optionally control access to the cluster


### PR DESCRIPTION
* attempt to fix gruntwork-io/terraform-google-gke/issues/118
* use services_secondary_range_name var instead of defaulting to cluster_secondary_range_name

This fix is in tandem with https://github.com/gruntwork-io/terraform-google-network/pull/62