### PR TITLE
Fix: pod secondary range name should not be same as service secondary range name

### DIFF
--- a/examples/gke-private-cluster/main.tf
+++ b/examples/gke-private-cluster/main.tf
@@ -45,7 +45,9 @@ module "gke_cluster" {
   # We're deploying the cluster in the 'public' subnetwork to allow outbound internet access
   # See the network access tier table for full details:
   # https://github.com/gruntwork-io/terraform-google-network/tree/master/modules/vpc-network#access-tier
-  subnetwork = module.vpc_network.public_subnetwork
+  subnetwork                    = module.vpc_network.public_subnetwork
+  cluster_secondary_range_name  = module.vpc_network.public_subnetwork_secondary_range_name
+  services_secondary_range_name = module.vpc_network.public_services_secondary_range_name
 
   # When creating a private cluster, the 'master_ipv4_cidr_block' has to be defined and the size must be /28
   master_ipv4_cidr_block = var.master_ipv4_cidr_block
@@ -68,8 +70,6 @@ module "gke_cluster" {
       ]
     },
   ]
-
-  cluster_secondary_range_name = module.vpc_network.public_subnetwork_secondary_range_name
 
   enable_vertical_pod_autoscaling = var.enable_vertical_pod_autoscaling
 
@@ -159,7 +159,7 @@ module "gke_service_account" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "vpc_network" {
-  source = "github.com/gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.6.0"
+  source = "github.com/gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.7.1"
 
   name_prefix = "${var.cluster_name}-network-${random_string.suffix.result}"
   project     = var.project
@@ -167,6 +167,13 @@ module "vpc_network" {
 
   cidr_block           = var.vpc_cidr_block
   secondary_cidr_block = var.vpc_secondary_cidr_block
+
+  public_subnetwork_secondary_range_name = var.public_subnetwork_secondary_range_name
+  public_services_secondary_range_name   = var.public_services_secondary_range_name
+  public_services_secondary_cidr_block   = var.public_services_secondary_cidr_block
+  private_services_secondary_cidr_block  = var.private_services_secondary_cidr_block
+  secondary_cidr_subnetwork_width_delta  = var.secondary_cidr_subnetwork_width_delta
+  secondary_cidr_subnetwork_spacing      = var.secondary_cidr_subnetwork_spacing
 }
 
 # Use a random suffix to prevent overlap in network names

--- a/examples/gke-private-cluster/variables.tf
+++ b/examples/gke-private-cluster/variables.tf
@@ -63,6 +63,42 @@ variable "vpc_secondary_cidr_block" {
   default     = "10.4.0.0/16"
 }
 
+variable "public_subnetwork_secondary_range_name" {
+  description = "The name associated with the pod subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-cluster"
+}
+
+variable "public_services_secondary_range_name" {
+  description = "The name associated with the services subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-services"
+}
+
+variable "public_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's public services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
+variable "private_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's private services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
+variable "secondary_cidr_subnetwork_width_delta" {
+  description = "The difference between your network and subnetwork's secondary range netmask; an /16 network and a /20 subnetwork would be 4."
+  type        = number
+  default     = 4
+}
+
+variable "secondary_cidr_subnetwork_spacing" {
+  description = "How many subnetwork-mask sized spaces to leave between each subnetwork type's secondary ranges."
+  type        = number
+  default     = 0
+}
+
 variable "enable_vertical_pod_autoscaling" {
   description = "Enable vertical pod autoscaling"
   type        = string

--- a/examples/gke-public-cluster/main.tf
+++ b/examples/gke-public-cluster/main.tf
@@ -41,14 +41,14 @@ module "gke_cluster" {
 
   project  = var.project
   location = var.location
+  network  = module.vpc_network.network
 
   # We're deploying the cluster in the 'public' subnetwork to allow outbound internet access
   # See the network access tier table for full details:
   # https://github.com/gruntwork-io/terraform-google-network/tree/master/modules/vpc-network#access-tier
-  network = module.vpc_network.network
-
-  subnetwork                   = module.vpc_network.public_subnetwork
-  cluster_secondary_range_name = module.vpc_network.public_subnetwork_secondary_range_name
+  subnetwork                    = module.vpc_network.public_subnetwork
+  cluster_secondary_range_name  = module.vpc_network.public_subnetwork_secondary_range_name
+  services_secondary_range_name = module.vpc_network.public_subnetwork_secondary_range_name
 
   alternative_default_service_account = var.override_default_node_pool_service_account ? module.gke_service_account.email : null
 
@@ -151,7 +151,7 @@ resource "random_string" "suffix" {
 }
 
 module "vpc_network" {
-  source = "github.com/gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.6.0"
+  source = "github.com/gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.7.1"
 
   name_prefix = "${var.cluster_name}-network-${random_string.suffix.result}"
   project     = var.project
@@ -159,4 +159,11 @@ module "vpc_network" {
 
   cidr_block           = var.vpc_cidr_block
   secondary_cidr_block = var.vpc_secondary_cidr_block
+
+  public_subnetwork_secondary_range_name = var.public_subnetwork_secondary_range_name
+  public_services_secondary_range_name   = var.public_services_secondary_range_name
+  public_services_secondary_cidr_block   = var.public_services_secondary_cidr_block
+  private_services_secondary_cidr_block  = var.private_services_secondary_cidr_block
+  secondary_cidr_subnetwork_width_delta  = var.secondary_cidr_subnetwork_width_delta
+  secondary_cidr_subnetwork_spacing      = var.secondary_cidr_subnetwork_spacing
 }

--- a/examples/gke-public-cluster/main.tf
+++ b/examples/gke-public-cluster/main.tf
@@ -48,7 +48,7 @@ module "gke_cluster" {
   # https://github.com/gruntwork-io/terraform-google-network/tree/master/modules/vpc-network#access-tier
   subnetwork                    = module.vpc_network.public_subnetwork
   cluster_secondary_range_name  = module.vpc_network.public_subnetwork_secondary_range_name
-  services_secondary_range_name = module.vpc_network.public_subnetwork_secondary_range_name
+  services_secondary_range_name = module.vpc_network.public_services_secondary_range_name
 
   alternative_default_service_account = var.override_default_node_pool_service_account ? module.gke_service_account.email : null
 

--- a/examples/gke-public-cluster/variables.tf
+++ b/examples/gke-public-cluster/variables.tf
@@ -57,6 +57,42 @@ variable "vpc_secondary_cidr_block" {
   default     = "10.7.0.0/16"
 }
 
+variable "public_subnetwork_secondary_range_name" {
+  description = "The name associated with the pod subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-cluster"
+}
+
+variable "public_services_secondary_range_name" {
+  description = "The name associated with the services subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-services"
+}
+
+variable "public_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's public services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
+variable "private_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's private services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
+variable "secondary_cidr_subnetwork_width_delta" {
+  description = "The difference between your network and subnetwork's secondary range netmask; an /16 network and a /20 subnetwork would be 4."
+  type        = number
+  default     = 4
+}
+
+variable "secondary_cidr_subnetwork_spacing" {
+  description = "How many subnetwork-mask sized spaces to leave between each subnetwork type's secondary ranges."
+  type        = number
+  default     = 0
+}
+
 variable "enable_vertical_pod_autoscaling" {
   description = "Enable vertical pod autoscaling"
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -90,11 +90,11 @@ module "gke_cluster" {
 
   project  = var.project
   location = var.location
-  network  = module.vpc_network.network
 
   # We're deploying the cluster in the 'public' subnetwork to allow outbound internet access
   # See the network access tier table for full details:
   # https://github.com/gruntwork-io/terraform-google-network/tree/master/modules/vpc-network#access-tier
+  network                      = module.vpc_network.network
   subnetwork                   = module.vpc_network.public_subnetwork
   cluster_secondary_range_name = module.vpc_network.public_subnetwork_secondary_range_name
 
@@ -194,7 +194,7 @@ resource "random_string" "suffix" {
 }
 
 module "vpc_network" {
-  source = "github.com/gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.6.0"
+  source = "github.com/gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.7.1"
 
   name_prefix = "${var.cluster_name}-network-${random_string.suffix.result}"
   project     = var.project
@@ -202,6 +202,13 @@ module "vpc_network" {
 
   cidr_block           = var.vpc_cidr_block
   secondary_cidr_block = var.vpc_secondary_cidr_block
+
+  public_subnetwork_secondary_range_name = var.public_subnetwork_secondary_range_name
+  public_services_secondary_range_name   = var.public_services_secondary_range_name
+  public_services_secondary_cidr_block   = var.public_services_secondary_cidr_block
+  private_services_secondary_cidr_block  = var.private_services_secondary_cidr_block
+  secondary_cidr_subnetwork_width_delta  = var.secondary_cidr_subnetwork_width_delta
+  secondary_cidr_subnetwork_spacing      = var.secondary_cidr_subnetwork_spacing
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -68,7 +68,7 @@ resource "google_container_cluster" "cluster" {
   ip_allocation_policy {
     // Choose the range, but let GCP pick the IPs within the range
     cluster_secondary_range_name  = var.cluster_secondary_range_name
-    services_secondary_range_name = var.services_secondary_range_name != null ? var.services_secondary_range_name : var.cluster_secondary_range_name
+    services_secondary_range_name = var.services_secondary_range_name
   }
 
   # We can optionally control access to the cluster

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,42 @@ variable "vpc_cidr_block" {
   default     = "10.3.0.0/16"
 }
 
+variable "public_subnetwork_secondary_range_name" {
+  description = "The name associated with the pod subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-cluster"
+}
+
+variable "public_services_secondary_range_name" {
+  description = "The name associated with the services subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-services"
+}
+
+variable "public_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's public services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
+variable "private_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's private services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
+variable "secondary_cidr_subnetwork_width_delta" {
+  description = "The difference between your network and subnetwork's secondary range netmask; an /16 network and a /20 subnetwork would be 4."
+  type        = number
+  default     = 4
+}
+
+variable "secondary_cidr_subnetwork_spacing" {
+  description = "How many subnetwork-mask sized spaces to leave between each subnetwork type's secondary ranges."
+  type        = number
+  default     = 0
+}
+
 # For the example, we recommend a /16 network for the secondary range. Note that when changing the size of the network,
 # you will have to adjust the 'cidr_subnetwork_width_delta' in the 'vpc_network' -module accordingly.
 variable "vpc_secondary_cidr_block" {


### PR DESCRIPTION
This PR fixes #118 by forcing the `gke-cluster` module to use `var.services_secondary_range_name` instead of defaulting to `var.cluster_secondary_range_name`. It also adds additional `vpc-network` options to each example in order to support backwards compatibility.
