### PR TITLE
[IAC-1677] Replace gofmt with goimports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
       - run:
           command: |
             pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0 yapf
+            go get golang.org/x/tools/cmd/goimports
+            export GOPATH=~/go/bin && export PATH=$PATH:$GOPATH 
             pre-commit install
             pre-commit run --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: v0.1.10
     hooks:
       - id: terraform-fmt
-      - id: gofmt
+      - id: goimports
 

--- a/test/terratest_options.go
+++ b/test/terratest_options.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/terraform"
 	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func createTestGKEBasicHelmTerraformOptions(


### PR DESCRIPTION
Replace gofmt with goimports in the pre-commit configuration. Note: This PR was opened using git-xargs.