### PR TITLE
feat: Add support for dns_cache_config addon (NodeLocal DNSCache)

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -91,6 +91,10 @@ resource "google_container_cluster" "cluster" {
     network_policy_config {
       disabled = !var.enable_network_policy
     }
+
+    dns_cache_config {
+      enabled = var.enable_dns_cache_config
+    }
   }
 
   network_policy {

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -227,3 +227,10 @@ variable "identity_namespace" {
   default     = null
   type        = string
 }
+
+# See https://cloud.google.com/kubernetes-engine/docs/how-to/nodelocal-dns-cache
+variable "enable_dns_cache_config" {
+  description = "Enable NodeLocal DNSCache on the cluster. Changing this property on an existing cluster is a disruptive process"
+  default = false
+  type = bool
+}


### PR DESCRIPTION
Added support the for dns_cache_config addon which provides NodeLocal DNSCache for improved DNS performance. The variable has a default value of false so unless a user overrides this specific property, no changes would be made.