### PR TITLE
Fix: google provider breaking changes in 4.0.0 #33

### DIFF
--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -172,18 +172,6 @@ variable "enable_network_policy" {
   default     = true
 }
 
-variable "basic_auth_username" {
-  description = "The username used for basic auth; set both this and `basic_auth_password` to \"\" to disable basic auth."
-  type        = string
-  default     = ""
-}
-
-variable "basic_auth_password" {
-  description = "The password used for basic auth; set both this and `basic_auth_username` to \"\" to disable basic auth."
-  type        = string
-  default     = ""
-}
-
 variable "enable_client_certificate_authentication" {
   description = "Whether to enable authentication by x509 certificates. With ABAC disabled, these certificates are effectively useless."
   type        = bool
@@ -222,8 +210,14 @@ variable "enable_workload_identity" {
   type        = bool
 }
 
-variable "identity_namespace" {
+variable "workload_pool" {
   description = "Workload Identity Namespace. Default sets project based namespace [project_id].svc.id.goog"
   default     = null
   type        = string
+}
+
+variable "enable_shielded_nodes" {
+  description = "Enable shielded nodes features on all nodes in this cluster. Default is set to true"
+  default     = true
+  type        = bool
 }


### PR DESCRIPTION
* Add variable for enabled_shieled_nodes
  hashicorp/terraform-provider-google#10403
* Add required client_certificate_config and remove username and password from master_auth
  hashicorp/terraform-provider-google#10441
* Update workload_identity_config to use workload pool instead of
  identity_namespace hashicorp/terraform-provider-google#10410